### PR TITLE
Add project id to helper

### DIFF
--- a/lib/editmode/chunk_value.rb
+++ b/lib/editmode/chunk_value.rb
@@ -10,10 +10,10 @@ module Editmode
 
     attr_writer :content
 
-    def initialize(identifier, **options)
+    def initialize(identifier, project_id: Editmode.project_id, **options)
       @identifier = identifier
       @branch_id = options[:branch_id].presence
-      @project_id = Editmode.project_id
+      @project_id = project_id
       @variable_values = options[:variables].presence || {}
       @raw = options[:raw].present?
       @skip_sanitize = options[:dangerously_skip_sanitization]


### PR DESCRIPTION
You can now use the `content_key` of the `project_id` that you specify directly in the helper and see it loaded in the page. However, editable helpers do not work.

Usage:
```erb
<%= e('my_content_key', project_id: 'prj_12flk1jf01') %>
```