### PR TITLE
Render noneditable image

### DIFF
--- a/lib/editmode/helper.rb
+++ b/lib/editmode/helper.rb
@@ -5,15 +5,32 @@ module Editmode
       field, options = parse_arguments(args)
       begin
         chunk = Editmode::ChunkValue.new(identifier, options.merge({raw: true}))
-
-        if chunk.chunk_type == 'collection_item'
-          chunk.field(field)
-        else
-          chunk.content
-        end 
+        render_noneditable_chunk(chunk, field, options)
       rescue => er
         puts er
       end
+    end
+
+    def render_noneditable_chunk(chunk, field=nil, options=nil)
+      return render_collection_item(chunk, field, options) if chunk.chunk_type == 'collection_item'
+
+      render_content(chunk, options)
+    end
+
+    def render_collection_item(chunk, field=nil, options=nil)
+      return render_image(chunk.field(field), options[:class]) if chunk.field_chunk(field)['chunk_type'] == 'image'
+
+      chunk.field(field)
+    end
+
+    def render_content(chunk, options=nil)
+      return render_image(chunk.content, options[:class]) if chunk.chunk_type == 'image'
+
+      chunk.content
+    end
+
+    def render_image(content, css_class=nil)
+      image_tag(content, class: css_class)
     end
 
     def render_custom_field_raw(label, options={})


### PR DESCRIPTION
## Problem
Using the `e` helper for:
-  a chunk type that's an `image`
- that's within a collection item or not 

doesn't actually render the image.

## Solution
- Render non-editable images similar to how `E` helper works