### PR TITLE
Add without_item_wrapper option for collection

### DIFF
--- a/lib/editmode/action_view_extensions/editmode_helper.rb
+++ b/lib/editmode/action_view_extensions/editmode_helper.rb
@@ -65,9 +65,13 @@ module Editmode
               content_tag :div, class: "chunks-collection-wrapper #{parent_class}", data: {chunk_collection_identifier: collection_identifier} do
                 chunks.each_with_index do |chunk, index|
                   @custom_field_chunk = chunk
-                  concat(content_tag(:div, class: "chunks-collection-item--wrapper #{item_class}") do
+                  if options[:without_item_wrapper].present?
                     yield(@custom_field_chunk, index)
-                  end)
+                  else
+                    concat(content_tag(:div, class: "chunks-collection-item--wrapper #{item_class}") do
+                      yield(@custom_field_chunk, index)
+                    end)
+                  end
                 end
 
                 # Placeholder element for new collection item

--- a/lib/editmode/version.rb
+++ b/lib/editmode/version.rb
@@ -1,3 +1,3 @@
 module Editmode
-  VERSION = "1.5.0"
+  VERSION = "1.6.0.pre.1"
 end


### PR DESCRIPTION
#24 


Update:
- Add `without_item_wrapper` option for `c` tag

Installation:
`gem 'editmode', '1.6.0.pre.1'`

```erb
 <%= c('collection-id', :without_item_wrapper => true) do %>
    <p><%= f('field') %></p>
 <% end %>
```

Would generate HTML

```html
 <div class="chunks-collection-wrapper" data-chunk-collection-identifier="[collection-id]">
   <p>field</p>
   <p>field</p>
   <p>field</p>
   .....
 </div>
```

**Important** : You can still edit all collection fields inline, but you won't be able to ADD or DELETE a collection inline.